### PR TITLE
Use FALLTHROUGH annotation to fix -Wimplicit-fallthrough warning

### DIFF
--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -110,7 +110,7 @@ COMPAT53_API void lua_len (lua_State *L, int i) {
     case LUA_TUSERDATA:
       if (luaL_callmeta(L, i, "__len"))
         break;
-      /* maybe fall through */
+      /* FALLTHROUGH */
     default:
       luaL_error(L, "attempt to get length of a %s value",
                  lua_typename(L, lua_type(L, i)));


### PR DESCRIPTION
Using a form that passes -Wimplicit-fallthrough=4.
See https://gcc.gnu.org/onlinedocs/gcc-7.1.0/gcc/Warning-Options.html#index-Wimplicit-fallthrough