### PR TITLE
LUA_ERRGCMM, luaL_loadbufferx, luaL_loadfilex

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For Lua 5.1 additionally:
 
 For Lua 5.1 additionally:
 * `LUA_OK`
+* `LUA_ERRGCMM`
 * `LUA_OP*` macros for `lua_arith` and `lua_compare`
 * `lua_Unsigned`
 * `lua_absindex`
@@ -158,6 +159,8 @@ For Lua 5.1 additionally:
 * `luaL_traceback`
 * `luaL_execresult`
 * `luaL_fileresult`
+* `luaL_loadfilex`
+* `luaL_loadbufferx`
 * `luaL_checkversion` (with empty body, only to avoid compile errors,
   see [here][20])
 * `luaL_tolstring`
@@ -166,6 +169,7 @@ For Lua 5.1 additionally:
 * `lua_pushunsigned`, `lua_tounsignedx`, `lua_tounsigned`,
   `luaL_checkunsigned`, `luaL_optunsigned`, if
   `LUA_COMPAT_APIINTCASTS` is defined.
+
 
 ## What's not implemented
 
@@ -185,8 +189,6 @@ For Lua 5.1 additionally:
   * `lua_upvaluejoin` (5.1)
   * `lua_version` (5.1)
   * `lua_yieldk` (5.1)
-  * `luaL_loadbufferx` (5.1)
-  * `luaL_loadfilex` (5.1)
 
 ## See also
 

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -540,7 +540,7 @@ COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char 
      * which does lock the file on VC++, define the macro used below
 	*/
 #if COMPAT53_FOPEN_NO_LOCK
-    lf.f = _fsopen(filename, mode, _SH_DENYNO); /* do not lock the file in any way */
+    lf.f = _fsopen(filename, "r", _SH_DENYNO); /* do not lock the file in any way */
     if (lf.f == NULL) {
       return compat53_errfile(L, "open", fnameindex);
     }

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -421,8 +421,12 @@ COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
 static const char* compat53_f_parser_handler (lua_State *L, void *data, size_t *size) {
   (void)L; /* better fix for unused parameter warnings */
   struct compat53_f_parser_buffer *p = (struct compat53_f_parser_buffer*)data;
+  if (feof(p->file) != 0) {
+	  *size = 0;
+	  return NULL;
+  }
   size_t readcount = fread(p->buffer + p->start, sizeof(*p->buffer), sizeof(p->buffer), p->file);
-  if (ferror(p->file) != 0 || feof(p->file) != 0) {
+  if (ferror(p->file) != 0) {
     *size = 0;
     return NULL;
   }
@@ -481,6 +485,7 @@ COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char 
   struct compat53_f_parser_buffer fbuf;
   fbuf.file = fp;
   fbuf.start = 1;
+  fbuf.buffer[0] = (char)c;
   status = lua_load(L, &compat53_f_parser_handler, &fbuf, filename);
   fclose(fp);
   return status;

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -387,17 +387,17 @@ COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
     /* use strerror_r here, because it's available on these specific platforms */
 #if defined(COMPAT53_HAVE_STRERROR_R_XSI)
     /* XSI Compliant */
-    strerror_r(en, buf, 512);
+    strerror_r(en, buf, sizeof(buf));
     s = buf;
 #else
     /* GNU-specific which returns const char* */
-    s = strerror_r(en, buf, 512);
+    s = strerror_r(en, buf, sizeof(buf));
 #endif
 #elif (defined(COMPAT53_HAVE_STRERROR_S) && COMPAT53_HAVE_STRERROR_S)
     /* for MSVC and other C11 implementations, use strerror_s 
      * since it's provided by default by the libraries 
      */
-    strerror_s(buf, 512, en);
+    strerror_s(buf, sizeof(buf), en);
     s = buf;
 #else
     /* fallback, but

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -17,20 +17,20 @@
 
 #if defined(__GLIBC__) || defined(_POSIX_VERSION) || defined(__APPLE__) || (!defined (__MINGW32__) && defined(__GNUC__) && (__GNUC__ < 6))
 #ifndef COMPAT53_HAVE_STRERROR_R
-#define COMPAT53_HAVE_STRERROR_R
+#define COMPAT53_HAVE_STRERROR_R 1
 #endif // have strerror_r
 #if ((defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || (defined(_XOPEN_SOURCE) || _XOPEN_SOURCE >= 600)) && (!defined(_GNU_SOURCE) || !_GNU_SOURCE)
 #ifndef COMPAT53_HAVE_STRERROR_R_XSI
-#define COMPAT53_HAVE_STRERROR_R_XSI
+#define COMPAT53_HAVE_STRERROR_R_XSI 1
 #endif // XSI-Compliant strerror_r
 #else
 #ifndef COMPAT53_HAVE_STRERROR_R_GNU
-#define COMPAT53_HAVE_STRERROR_R_GNU
+#define COMPAT53_HAVE_STRERROR_R_GNU 1
 #endif // GNU variant strerror_r
 #endif // XSI/Posix vs. GNU strerror_r
 #elif defined(_MSC_VER) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || defined(__STDC_LIB_EXT1__)
 #ifndef COMPAT53_HAVE_STRERROR_S
-#define COMPAT53_HAVE_STRERROR_S
+#define COMPAT53_HAVE_STRERROR_S 1
 #endif // GNU variant strerror_r
 #endif // strerror_r vs. strerror_s vs. strerror usage
 
@@ -369,7 +369,7 @@ COMPAT53_API void luaL_traceback (lua_State *L, lua_State *L1,
 COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
   const char* s = NULL;
   int en = errno;  /* calls to Lua API may change this value */
-#if defined(COMPAT53_HAVE_STRERROR_R) || defined(COMPAT53_HAVE_STRERROR_S)
+#if (defined(COMPAT53_HAVE_STRERROR_R) && COMPAT53_HAVE_STRERROR_R) || (defined(COMPAT53_HAVE_STRERROR_S) && COMPAT53_HAVE_STRERROR_S)
   char buf[512] = { 0 };
 #endif // buffer for threadsafe variants of strerror if possible
   if (stat) {
@@ -388,7 +388,7 @@ COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
     /* GNU-specific which returns const char* */
     s = strerror_r(en, buf, 512);
 #endif
-#elif defined(COMPAT53_HAVE_STRERROR_S)
+#elif (defined(COMPAT53_HAVE_STRERROR_S) && COMPAT53_HAVE_STRERROR_S)
     /* for MSVC and other C11 implementations, use strerror_s 
      * since it's provided by default by the libraries 
      */
@@ -413,7 +413,8 @@ COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
 }
 
 
-static const char* compat53_f_parser_handler (lua_State *, void *data, size_t *size) {
+static const char* compat53_f_parser_handler (lua_State *L, void *data, size_t *size) {
+  (void)L; // better fix for unused parameter warnings
   struct compat53_f_parser_buffer *p = (struct compat53_f_parser_buffer*)data;
   size_t readcount = fread(p->buffer + p->start, sizeof(*p->buffer), sizeof(p->buffer), p->file);
   if (ferror(p->file) != 0 || feof(p->file) != 0) {

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -44,12 +44,35 @@
 #define COMPAT53_LUA_FILE_BUFFER_SIZE 4096
 #endif /* Lua File Buffer Size */
 
-struct compat53_f_parser_buffer {
-  FILE* file;
-  size_t start;
-  char buffer[COMPAT53_LUA_FILE_BUFFER_SIZE];
-};
-
+static char* compat53_strerror(int en, char* buff, size_t sz) {
+#if COMPAT53_HAVE_STRERROR_R
+	/* use strerror_r here, because it's available on these specific platforms */
+#if defined(COMPAT53_HAVE_STRERROR_R_XSI)
+	/* XSI Compliant */
+	strerror_r(en, buf, sz);
+	return buf;
+#else
+	/* GNU-specific which returns const char* */
+	return strerror_r(en, buf, sz);
+#endif
+#elif COMPAT53_HAVE_STRERROR_S
+	/* for MSVC and other C11 implementations, use strerror_s
+	* since it's provided by default by the libraries
+	*/
+	strerror_s(buff, sz, en);
+	return buff;
+#else
+	/* fallback, but
+	* strerror is not guaranteed to be threadsafe due to modifying
+	* errno itself and some impls not locking a static buffer for it
+	* ... but most known systems have threadsafe errno: this might only change
+	* if the locale is changed out from under someone while this function is being called
+	*/
+	(void)buff;
+	(void)sz;
+	return strerror(en);
+#endif
+}
 
 COMPAT53_API int lua_absindex (lua_State *L, int i) {
   if (i < 0 && i > LUA_REGISTRYINDEX)
@@ -372,133 +395,171 @@ COMPAT53_API void luaL_traceback (lua_State *L, lua_State *L1,
 
 
 COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
-  const char* s = NULL;
+  const char *serr = NULL;
   int en = errno;  /* calls to Lua API may change this value */
-#if (defined(COMPAT53_HAVE_STRERROR_R) && COMPAT53_HAVE_STRERROR_R) || (defined(COMPAT53_HAVE_STRERROR_S) && COMPAT53_HAVE_STRERROR_S)
   char buf[512] = { 0 };
-#endif /* buffer for threadsafe variants of strerror if possible */
   if (stat) {
     lua_pushboolean(L, 1);
     return 1;
   }
   else {
     lua_pushnil(L);
-#if (defined(COMPAT53_HAVE_STRERROR_R) && COMPAT53_HAVE_STRERROR_R)
-    /* use strerror_r here, because it's available on these specific platforms */
-#if defined(COMPAT53_HAVE_STRERROR_R_XSI)
-    /* XSI Compliant */
-    strerror_r(en, buf, sizeof(buf));
-    s = buf;
-#else
-    /* GNU-specific which returns const char* */
-    s = strerror_r(en, buf, sizeof(buf));
-#endif
-#elif (defined(COMPAT53_HAVE_STRERROR_S) && COMPAT53_HAVE_STRERROR_S)
-    /* for MSVC and other C11 implementations, use strerror_s 
-     * since it's provided by default by the libraries 
-     */
-    strerror_s(buf, sizeof(buf), en);
-    s = buf;
-#else
-    /* fallback, but
-     * strerror is not guaranteed to be threadsafe due to modifying
-     * errno itself and some impls not locking a static buffer for it
-     * ... but most known systems have threadsafe errno: this might only change
-     * if the locale is changed out from under someone while this function is being called
-     */ 
-    s = strerror(en);
-#endif
+    serr = compat53_strerror(en, buf, sizeof(buf));
     if (fname)
-      lua_pushfstring(L, "%s: %s", fname, s);
+      lua_pushfstring(L, "%s: %s", fname, serr);
     else
-      lua_pushstring(L, s);
+      lua_pushstring(L, serr);
     lua_pushnumber(L, (lua_Number)en);
     return 3;
   }
 }
 
 
-static const char* compat53_f_parser_handler (lua_State *L, void *data, size_t *size) {
-  (void)L; /* better fix for unused parameter warnings */
-  struct compat53_f_parser_buffer *p = (struct compat53_f_parser_buffer*)data;
-  if (feof(p->file) != 0) {
-	  *size = 0;
-	  return NULL;
-  }
-  size_t readcount = fread(p->buffer + p->start, sizeof(*p->buffer), sizeof(p->buffer), p->file);
-  if (ferror(p->file) != 0) {
-    *size = 0;
-    return NULL;
-  }
-  *size = readcount + p->start;
-  p->start = 0;
-  return p->buffer;
-}
-
-
-static int checkmode (lua_State *L, const char *mode, const char *modename, int err) {
+static int compat53_checkmode (lua_State *L, const char *mode, const char *modename, int err) {
   if (mode && strchr(mode, modename[0]) == NULL) {
-    lua_pushfstring(L, "attempt to load a %s chunk (mode is '%s')", modename, mode);
+    lua_pushfstring(L, "attempt to load a %s chunk when 'mode' is '%s'", modename, mode);
     return err;
   }
   return LUA_OK;
 }
 
 
-COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char *mode) {
-  FILE* fp;
+typedef struct compat53_LoadF {
+  int n;  /* number of pre-read characters */
+  FILE *f;  /* file being read */
+  char buff[COMPAT53_LUA_FILE_BUFFER_SIZE];  /* area for reading file */
+} compat53_LoadF;
+
+
+static const char *getF (lua_State *L, void *ud, size_t *size) {
+  compat53_LoadF *lf = (compat53_LoadF *)ud;
+  (void)L;  /* not used */
+  if (lf->n > 0) {  /* are there pre-read characters to be read? */
+    *size = lf->n;  /* return them (chars already in buffer) */
+    lf->n = 0;  /* no more pre-read characters */
+  }
+  else {  /* read a block from file */
+    /* 'fread' can return > 0 *and* set the EOF flag. If next call to
+       'getF' called 'fread', it might still wait for user input.
+       The next check avoids this problem. */
+    if (feof(lf->f)) return NULL;
+    *size = fread(lf->buff, 1, sizeof(lf->buff), lf->f);  /* read block */
+  }
+  return lf->buff;
+}
+
+
+static int compat53_errfile (lua_State *L, const char *what, int fnameindex) {
+  char buf[512] = {0};
+  const char *serr = compat53_strerror(errno, buf, sizeof(buf));
+  const char *filename = lua_tostring(L, fnameindex) + 1;
+  lua_pushfstring(L, "cannot %s %s: %s", what, filename, serr);
+  lua_remove(L, fnameindex);
+  return LUA_ERRFILE;
+}
+
+
+static int compat53_skipBOM (compat53_LoadF *lf) {
+  const char *p = "\xEF\xBB\xBF";  /* UTF-8 BOM mark */
   int c;
-  int status = LUA_OK;
-#if defined(_MSC_VER)
-  int err = 0;
-  err = fopen_s(&fp, filename, "rb");
-  if (err != 0) {
-    fclose(fp);
-    lua_pushfstring(L, "cannot open file '%s'", filename);
-    return LUA_ERRFILE;
+  lf->n = 0;
+  do {
+    c = getc(lf->f);
+    if (c == EOF || c != *(const unsigned char *)p++) return c;
+    lf->buff[lf->n++] = c;  /* to be read by the parser */
+  } while (*p != '\0');
+  lf->n = 0;  /* prefix matched; discard it */
+  return getc(lf->f);  /* return next character */
+}
+
+
+/*
+** reads the first character of file 'f' and skips an optional BOM mark
+** in its beginning plus its first line if it starts with '#'. Returns
+** true if it skipped the first line.  In any case, '*cp' has the
+** first "valid" character of the file (after the optional BOM and
+** a first-line comment).
+*/
+static int compat53_skipcomment (compat53_LoadF *lf, int *cp) {
+  int c = *cp = compat53_skipBOM(lf);
+  if (c == '#') {  /* first line is a comment (Unix exec. file)? */
+    do {  /* skip first line */
+      c = getc(lf->f);
+    } while (c != EOF && c != '\n');
+    *cp = getc(lf->f);  /* skip end-of-line, if present */
+    return 1;  /* there was a comment */
   }
-#else /* fopen error on Visual C */
-  fp = fopen(filename, "rb");
-  if (fp == NULL) {
-    fclose(fp);
-    lua_pushfstring(L, "cannot open file '%s'", filename);
-    return LUA_ERRFILE;
-  }
-#endif /* fopen error on Visual C */
-  c = fgetc(fp);
-  if (ferror(fp) != 0) {
-    /* can't read even a single character */
-    fclose(fp);
-    lua_pushfstring(L, "cannot read from file '%s'", filename);
-    return LUA_ERRFILE;
-  }
-  if (c == '\x1b') {
-    status = checkmode(L, mode, "binary", LUA_ERRFILE);
+  else return 0;  /* no comment */
+}
+
+
+COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char *mode) {
+  static const char lua_signature[] = "\x1bLua";
+  compat53_LoadF lf;
+  int status, readstatus;
+  int c;
+  int fnameindex = lua_gettop(L) + 1;  /* index of filename on the stack */
+  if (filename == NULL) {
+    lua_pushliteral(L, "=stdin");
+    lf.f = stdin;
   }
   else {
-    status = checkmode(L, mode, "text", LUA_ERRFILE);
+    lua_pushfstring(L, "@%s", filename);
+#if defined(_MSC_VER)
+    /* a quick check shows that fopen_s this goes back to VS 2005, possibly even before that 
+     * so we don't need to do any version number checks, 
+	* since this has been there since forever
+	*/
+    if (fopen_s(&lf.f, filename, "r") != 0) return compat53_errfile(L, "open", fnameindex);
+#else
+    lf.f = fopen(filename, "r");
+    if (lf.f == NULL) return compat53_errfile(L, "open", fnameindex);
+#endif
   }
-  if (status != LUA_OK) {
-    fclose(fp);
-    return status;
+  if (compat53_skipcomment(&lf, &c))  /* read initial portion */
+    lf.buff[lf.n++] = '\n';  /* add line to correct line numbers */
+  if (c == lua_signature[0]) {  /* binary file? */
+    status = compat53_checkmode(L, mode, "binary", LUA_ERRFILE);
+    if (status != LUA_OK) {
+      fclose(lf.f);
+      return compat53_errfile(L, "improper mode", fnameindex);
+    }
+#if defined(_MSC_VER)
+    if (freopen_s(&lf.f, filename, "r", lf.f) != 0) return compat53_errfile(L, "open", fnameindex);
+#else
+    lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
+    if (lf.f == NULL) return compat53_errfile(L, "reopen", fnameindex);
+#endif
+    compat53_skipcomment(&lf, &c);  /* re-read initial portion */
   }
-  struct compat53_f_parser_buffer fbuf;
-  fbuf.file = fp;
-  fbuf.start = 1;
-  fbuf.buffer[0] = (char)c;
-  status = lua_load(L, &compat53_f_parser_handler, &fbuf, filename);
-  fclose(fp);
+  else { /* text file */
+    status = compat53_checkmode(L, mode, "text", LUA_ERRFILE);
+    if (status != LUA_OK) {
+      fclose(lf.f);
+      return compat53_errfile(L, "improper mode", fnameindex);
+    }    
+  }
+  if (c != EOF)
+    lf.buff[lf.n++] = c;  /* 'c' is the first character of the stream */
+  status = lua_load(L, getF, &lf, lua_tostring(L, -1));
+  readstatus = ferror(lf.f);
+  if (filename) fclose(lf.f);  /* close file (even in case of errors) */
+  if (readstatus) {
+    lua_settop(L, fnameindex);  /* ignore results from 'lua_load' */
+    return compat53_errfile(L, "read", fnameindex);
+  }
+  lua_remove(L, fnameindex);
   return status;
 }
 
 
 COMPAT53_API int luaL_loadbufferx (lua_State *L, const char *buff, size_t sz, const char *name, const char *mode) {
   int status = LUA_OK;
-  if (buff[0] == '\x1b') {
-    status = checkmode(L, mode, "binary", LUA_ERRSYNTAX);
+  if (sz > 0 && buff[0] == '\x1b') {
+    status = compat53_checkmode(L, mode, "binary", LUA_ERRSYNTAX);
   }
   else {
-    status = checkmode(L, mode, "text", LUA_ERRSYNTAX);
+    status = compat53_checkmode(L, mode, "text", LUA_ERRSYNTAX);
   }
   if (status != LUA_OK)
     return status;

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -49,11 +49,11 @@ static char* compat53_strerror(int en, char* buff, size_t sz) {
 	/* use strerror_r here, because it's available on these specific platforms */
 #if defined(COMPAT53_HAVE_STRERROR_R_XSI)
 	/* XSI Compliant */
-	strerror_r(en, buf, sz);
-	return buf;
+	strerror_r(en, buff, sz);
+	return buff;
 #else
 	/* GNU-specific which returns const char* */
-	return strerror_r(en, buf, sz);
+	return strerror_r(en, buff, sz);
 #endif
 #elif COMPAT53_HAVE_STRERROR_S
 	/* for MSVC and other C11 implementations, use strerror_s

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -358,7 +358,7 @@ COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
     lua_pushnil(L);
 #if defined(__GLIBC__) || defined(_POSIX_VERSION) || defined(__APPLE__) || (!defined (__MINGW32__) && defined(__GNUC__) && (__GNUC__ < 6))
     /* use strerror_r here, because it's available on these specific platforms */
-    char buf[512] = {};
+    char buf[512] = {0};
 #if ((defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || (defined(_XOPEN_SOURCE) || _XOPEN_SOURCE >= 600)) && (!defined(_GNU_SOURCE) || !_GNU_SOURCE)
     /* XSI Compliant */
     strerror_r(en, buf, 512);
@@ -371,7 +371,7 @@ COMPAT53_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
     /* for MSVC and other C11 implementations, use strerror_s 
      * since it's provided by default by the libraries 
 	*/
-    char buf[512] = {};
+    char buf[512] = {0};
     strerror_s(buf, 512, en);
     s = buf;
 #else

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -457,8 +457,10 @@ COMPAT53_API int luaL_loadfilex(lua_State *L, const char *filename, const char *
   allowbinary = mode[0] == 'b'; 
   allowtext = mode[0] == 't';
   if (modesize > 1) {
-    allowbinary = mode[1] == 'b';
-    allowtext = mode[1] == 't';
+    // manual only says "t", "b", or "bt", but tests against 
+    // Lua 5.2 and 5.3 show that "tb" is also allowed
+    allowbinary = allowbinary || mode[1] == 'b';
+    allowtext = allowtext || mode[1] == 't';
   }
 
   if (!allowbinary || !allowtext) {
@@ -467,7 +469,7 @@ COMPAT53_API int luaL_loadfilex(lua_State *L, const char *filename, const char *
   }
   else if (allowbinary && allowtext) {
      // both modes allowed: just pass it through
-     luaL_loadfile(L, filename);
+     return luaL_loadfile(L, filename);
   }
   // otherwise, we have to check manually ourselves
 #if defined(_MSC_VER)
@@ -501,8 +503,6 @@ COMPAT53_API int luaL_loadfilex(lua_State *L, const char *filename, const char *
 
 COMPAT53_API int luaL_loadbufferx(lua_State *L, const char *buff, size_t sz, const char *name, const char *mode) {
   size_t modesize;
-  FILE* fp;
-  errno_t err
   int allowbinary = 0;
   int allowtext = 0;
   if (mode == NULL) {
@@ -520,8 +520,10 @@ COMPAT53_API int luaL_loadbufferx(lua_State *L, const char *buff, size_t sz, con
   allowbinary = mode[0] == 'b'; 
   allowtext = mode[0] == 't';
   if (modesize > 1) {
-    allowbinary = mode[1] == 'b';
-    allowtext = mode[1] == 't';
+    // manual only says "t", "b", or "bt", but tests against 
+    // Lua 5.2 and 5.3 show that "tb" is also allowed
+    allowbinary = allowbinary || mode[1] == 'b';
+    allowtext = allowtext || mode[1] == 't';
   }
 
   if (!allowbinary || !allowtext) {
@@ -530,7 +532,7 @@ COMPAT53_API int luaL_loadbufferx(lua_State *L, const char *buff, size_t sz, con
   }
   else if (allowbinary && allowtext) {
      // both modes allowed: just pass it through
-     luaL_loadbuffer(L, buff, sz, name);
+     return luaL_loadbuffer(L, buff, sz, name);
   }
   // otherwise, we have to check manually ourselves
   if (allowbinary) {

--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -25,7 +25,7 @@
 
 #if defined(_MSC_VER) && COMPAT53_FOPEN_NO_LOCK
 #include <share.h>
-#endif // VC++ _fsopen for share-allowed file read
+#endif /* VC++ _fsopen for share-allowed file read */
 
 #ifndef COMPAT53_HAVE_STRERROR_R
 #  if defined(__GLIBC__) || defined(_POSIX_VERSION) || defined(__APPLE__) || (!defined (__MINGW32__) && defined(__GNUC__) && (__GNUC__ < 6))
@@ -530,6 +530,11 @@ COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char 
   else {
     lua_pushfstring(L, "@%s", filename);
 #if defined(_MSC_VER)
+	/* this code is here to stop a deprecation error that 
+	 * stops builds if a certain macro is defined
+	 * while normally not caring would be best, some 
+	 * header-only libraries and builds can't afford
+	 * to dictate this to the user*/
     /* a quick check shows that fopen_s this goes back to VS 2005, 
      * and _fsopen goes back to VS 2003 .NET, possibly even before that 
      * so we don't need to do any version number checks, 
@@ -537,7 +542,7 @@ COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char 
      */
 
     /* TO USER: if you want the behavior of typical fopen_s/fopen, 
-     * which does lock the file on VC++, define the macro used below
+     * which does lock the file on VC++, define the macro used below to 0
 	*/
 #if COMPAT53_FOPEN_NO_LOCK
     lf.f = _fsopen(filename, "r", _SH_DENYNO); /* do not lock the file in any way */

--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -166,10 +166,10 @@ COMPAT53_API lua_Number lua_tonumberx (lua_State *L, int i, int *isnum);
 COMPAT53_API void luaL_checkversion (lua_State *L);
 
 #define luaL_loadfilex COMPAT53_CONCAT(COMPAT53_PREFIX, L_loadfilex)
-COMPAT53_API void luaL_loadfilex (lua_State *L, const char *filename, const char *mode);
+COMPAT53_API int luaL_loadfilex (lua_State *L, const char *filename, const char *mode);
 
 #define luaL_loadbufferx COMPAT53_CONCAT(COMPAT53_PREFIX, L_loadbufferx)
-COMPAT53_API void luaL_loadbufferx (lua_State *L, const char *buff, size_t sz, const char *name, const char *mode);
+COMPAT53_API int luaL_loadbufferx (lua_State *L, const char *buff, size_t sz, const char *name, const char *mode);
 
 #define luaL_checkstack COMPAT53_CONCAT(COMPAT53_PREFIX, L_checkstack_53)
 COMPAT53_API void luaL_checkstack (lua_State *L, int sp, const char *msg);

--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -166,10 +166,10 @@ COMPAT53_API lua_Number lua_tonumberx (lua_State *L, int i, int *isnum);
 COMPAT53_API void luaL_checkversion (lua_State *L);
 
 #define luaL_loadfilex COMPAT53_CONCAT(COMPAT53_PREFIX, L_loadfilex)
-COMPAT53_API void luaL_loadfilex (lua_State *L);
+COMPAT53_API void luaL_loadfilex (lua_State *L, const char *filename, const char *mode);
 
 #define luaL_loadbufferx COMPAT53_CONCAT(COMPAT53_PREFIX, L_loadbufferx)
-COMPAT53_API void luaL_loadbufferx (lua_State *L);
+COMPAT53_API void luaL_loadbufferx (lua_State *L, const char *buff, size_t sz, const char *name, const char *mode);
 
 #define luaL_checkstack COMPAT53_CONCAT(COMPAT53_PREFIX, L_checkstack_53)
 COMPAT53_API void luaL_checkstack (lua_State *L, int sp, const char *msg);

--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -50,8 +50,6 @@ extern "C" {
  * lua_upvaluejoin
  * lua_version
  * lua_yieldk
- * luaL_loadbufferx
- * luaL_loadfilex
  */
 
 #ifndef LUA_OK
@@ -87,6 +85,13 @@ extern "C" {
 #ifndef LUA_OPLE
 #  define LUA_OPLE 2
 #endif
+
+// LuaJIT/Lua 5.1 does not have the updated 
+// error codes for thread status/function returns (but some patched versions do)
+// define it only if it's not found
+#if !defined(LUA_ERRGCMM)
+#  define LUA_ERRGCMM (LUA_ERRERR + 2) // + 2 because in some version something is already defined at LUA_ERRERR + 1
+#endif // LUA_ERRGCMM define
 
 typedef size_t lua_Unsigned;
 
@@ -153,6 +158,12 @@ COMPAT53_API lua_Number lua_tonumberx (lua_State *L, int i, int *isnum);
 
 #define luaL_checkversion COMPAT53_CONCAT(COMPAT53_PREFIX, L_checkversion)
 COMPAT53_API void luaL_checkversion (lua_State *L);
+
+#define luaL_loadfilex COMPAT53_CONCAT(COMPAT53_PREFIX, L_loadfilex)
+COMPAT53_API void luaL_loadfilex (lua_State *L);
+
+#define luaL_loadbufferx COMPAT53_CONCAT(COMPAT53_PREFIX, L_loadbufferx)
+COMPAT53_API void luaL_loadbufferx (lua_State *L);
 
 #define luaL_checkstack COMPAT53_CONCAT(COMPAT53_PREFIX, L_checkstack_53)
 COMPAT53_API void luaL_checkstack (lua_State *L, int sp, const char *msg);

--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -86,12 +86,18 @@ extern "C" {
 #  define LUA_OPLE 2
 #endif
 
-// LuaJIT/Lua 5.1 does not have the updated 
-// error codes for thread status/function returns (but some patched versions do)
-// define it only if it's not found
+/* LuaJIT/Lua 5.1 does not have the updated 
+ * error codes for thread status/function returns (but some patched versions do)
+ * define it only if it's not found
+ */
 #if !defined(LUA_ERRGCMM)
-#  define LUA_ERRGCMM (LUA_ERRERR + 2) // + 2 because in some version something is already defined at LUA_ERRERR + 1
-#endif // LUA_ERRGCMM define
+/* Use + 2 because in some versions of Lua (Lua 5.1) 
+ * LUA_ERRFILE is defined as (LUA_ERRERR+1)
+ * so we need to avoid it (LuaJIT might have something at this
+ * integer value too)
+ */
+#  define LUA_ERRGCMM (LUA_ERRERR + 2)
+#endif /* LUA_ERRGCMM define */
 
 typedef size_t lua_Unsigned;
 


### PR DESCRIPTION
This pull request implements several changes to address builds on MinGW, Android, and Visual C++ builds trying to avoid deprecation errors and warnings, as well as compiler errors from missing functions. This is the full code necessary to allow sol2 to directly use this compatibility shim, as per @daurnimator's request of me.

It addresses #29 and #30.

Firstly, this implementation defines a few helpers made static in this implementation:
* `COMPAT53_LUA_FILE_BUFFER_SIZE` macro, for buffered reads using the above structure and function
* `compat53_strerror` allows us to normalize differences between implementations and avoid linter error checks
* `COMPAT53_FOPEN_NO_LOCK` macro, see discussion below of `luaL_loadfilex`


# Implementation notes

* For `luaL_fileresult`

Usage of `strerror` directly in `luaL_fileresult` results in a deprecation error. Because this deprecation error's "turn me off" macros and others may change the library's looks and this may be included in header-only projects which do not have the privilege of dictating to the user what they can and cannot define when working with the code, I have added a check for `_MSC_VER` to check for VC++ and thusly call `strerror_s`. This is all put inside of `compat53_strerror`.

* For `luaL_loadfilex`

We take Lua 5.3's implementation, with a few additional checks added since Lua 5.3's `loadfilex` implementation depends on `lua_load` checking the `mode` parameter (and in 5.1 it doesn't take a load parameter), so we do that with our own `compat53_checkmode`.

Additionally, `COMPAT53_FOPEN_NO_LOCK` defined to `0` changes the usage of MSVC's `_fsopen` to `fopen_s`. The reason this is an explicit opt-in macro is because the default behavior of `fopen` (and the reason Microsoft considers it unsafe, along with other reasons) is that `fopen` does not lock the file for reading or writing. `fopen_s` does, but we want to maintain the same semantics as Lua would have if it opened the file: therefore, this macro is an opt-in macro, that defaults to being defined to `1` and using the internal function `_fsopen` with the flag `_SHDENYNO` to have the exact same semantics as `fopen` without the error killing the build.

* For `luaL_loadbufferx`

Similar to  `luaL_loadfilex`, without as much effort for having to open the file to check for the first character. The size is checked and the buffer validated for being a text vs. binary, before continuing on with the processing.

* For `lua_len`

The patch for this function specifically avoids a warning since `lua_pushnumber` takes a `lua_Number` (double) and there is a conversion warning when going from the casted-to `lua_Integer`. I changed the cast to `lua_Number` to avoid the warning in VC++.


I tried to keep the implementation as clean as possible. If you have any questions or comments, please comment here or at the line of code with the error and I will do my best to fix it.

Thank you for your time.