### PR TITLE
LUA_ERRGCMM define

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For Lua 5.1 additionally:
 
 For Lua 5.1 additionally:
 * `LUA_OK`
+* `LUA_ERRGCMM`
 * `LUA_OP*` macros for `lua_arith` and `lua_compare`
 * `lua_Unsigned`
 * `lua_absindex`

--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -88,6 +88,19 @@ extern "C" {
 #  define LUA_OPLE 2
 #endif
 
+/* LuaJIT/Lua 5.1 does not have the updated 
+ * error codes for thread status/function returns (but some patched versions do)
+ * define it only if it's not found
+ */
+#if !defined(LUA_ERRGCMM)
+/* Use + 2 because in some versions of Lua (Lua 5.1) 
+ * LUA_ERRFILE is defined as (LUA_ERRERR+1)
+ * so we need to avoid it (LuaJIT might have something at this
+ * integer value too)
+ */
+#  define LUA_ERRGCMM (LUA_ERRERR + 2)
+#endif /* LUA_ERRGCMM define */
+
 typedef size_t lua_Unsigned;
 
 typedef struct luaL_Buffer_53 {


### PR DESCRIPTION
This Pull Request implements part of #31 and defines the missing error code `LUA_ERRGCMM`. It also adds it to the README as one of the error codes defined for Lua 5.1.