### PR TITLE
implement lua_getextraspace by storing the contents in the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ For Lua 5.1 additionally:
 * `luaL_requiref` (now checks `package.loaded` first)
 * `lua_rotate`
 * `lua_stringtonumber` (see [here][18])
+* `lua_getextraspace` (limited compatability, can store `sizeof(void*)`)
 
 For Lua 5.1 additionally:
 * `LUA_OK`
@@ -186,7 +187,6 @@ For Lua 5.1 additionally:
   [`lua-compat-5.2`][2] for a detailed list.
 * the following C API functions/macros:
   * `lua_isyieldable`
-  * `lua_getextraspace`
   * `lua_arith` (new operators missing)
   * `lua_push(v)fstring` (new formats missing)
   * `lua_upvalueid` (5.1)

--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -330,6 +330,11 @@ COMPAT53_API const char *luaL_tolstring (lua_State *L, int idx, size_t *len);
 COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
                                  lua_CFunction openf, int glb );
 
+#define lua_close COMPAT53_CONCAT(COMPAT53_PREFIX, _close_53)
+COMPAT53_API void lua_close(lua_State *L);
+
+COMPAT53_API void *lua_getextraspace(lua_State *L);
+
 #endif /* Lua 5.1 and Lua 5.2 */
 
 
@@ -339,7 +344,6 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 
 /* XXX not implemented:
  * lua_isyieldable
- * lua_getextraspace
  * lua_arith (new operators)
  * lua_pushfstring (new formats)
  */


### PR DESCRIPTION
So this is a bit of a clever hack for supporting `lua_getextraspace` without much intrusiveness, or changes to existing Lua libraries. The general idea is to use the Lua allocator which can be obtained with `lua_getallocf` to allocate exactly `sizeof(void*)` bytes, which is the default size that ships with Lua 5.3 unless you compile your own, to store the extra data. The registry is used to keep track of this, so it's not actually exposed to Lua. The somewhat intrusive part is that `lua_close` has to be modified so that it can call upon the allocator to free that memory otherwise we have a memory leak. This also works with new Lua threads since the registry is shared with those.