### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c
 compiler: gcc
 
+os: linux
+arch:
+ - amd64
+ - ppc64le
+ 
 sudo: false
 
 env:
@@ -16,6 +21,17 @@ env:
   - LUA="lua=5.2" EXTERNAL=true
   - LUA="lua=5.2" COMPILER="g++"
   - LUA="lua=5.2" EXTERNAL=true COMPILER="g++"
+  
+jobs:
+  exclude:
+      - arch: ppc64le
+        env: LUA="luajit=@v2.1 --compat=none"
+      - arch: ppc64le
+        env: LUA="luajit=@v2.1 --compat=none" EXTERNAL=true
+      - arch: ppc64le
+        env: LUA="luajit=@v2.1 --compat=all"
+      - arch: ppc64le
+        env: LUA="luajit=@v2.1 --compat=all" EXTERNAL=true
 
 branches:
   only:


### PR DESCRIPTION
Add support for architecture ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
Added ppc64le arch and excluded luajit=@v2.1 for Travis build.